### PR TITLE
fix: FetchEventImpl constructor

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -18,21 +18,21 @@ class FetchEventImpl extends Event {
     super("fetch");
 
     const host = stdReq.headers.get("host") ?? "example.com";
+    const method = stdReq.method;
+    const body = (method === "GET" || method === "HEAD")
+      ? null
+      : new ReadableStream({
+        start: async (controller) => {
+          for await (const chunk of Deno.iter(stdReq.body)) {
+            controller.enqueue(chunk);
+          }
+          controller.close();
+        },
+      });
 
     this.request = new Request(
       new URL(stdReq.url, `http://${host}`).toString(),
-      {
-        body: new ReadableStream({
-          start: async (controller) => {
-            for await (const chunk of Deno.iter(stdReq.body)) {
-              controller.enqueue(chunk);
-            }
-            controller.close();
-          },
-        }),
-        headers: stdReq.headers,
-        method: stdReq.method,
-      },
+      { body, headers: stdReq.headers, method },
     );
   }
 


### PR DESCRIPTION
Request constructor throws a type error when the method is GET or HEAD and body is not null. This PR avoids that error by checking the method and set body null when method is GET or HEAD.