### PR TITLE
Fix request body handling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -18,21 +18,21 @@ class FetchEventImpl extends Event {
     super("fetch");
 
     const host = stdReq.headers.get("host") ?? "example.com";
+    const method = stdReq.method;
+    const body = (method === "GET" || method === "HEAD")
+      ? null
+      : new ReadableStream({
+        start: async (controller) => {
+          for await (const chunk of Deno.iter(stdReq.body)) {
+            controller.enqueue(chunk);
+          }
+          controller.close();
+        },
+      });
 
     this.request = new Request(
       new URL(stdReq.url, `http://${host}`).toString(),
-      {
-        body: new ReadableStream({
-          start: async (controller) => {
-            for await (const chunk of Deno.iter(stdReq.body)) {
-              controller.enqueue(chunk);
-            }
-            controller.close();
-          },
-        }),
-        headers: stdReq.headers,
-        method: stdReq.method,
-      },
+      { body, headers: stdReq.headers, method },
     );
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ class FetchEventImpl extends Event {
       : new ReadableStream({
         start: async (controller) => {
           for await (const chunk of Deno.iter(stdReq.body)) {
-            controller.enqueue(chunk);
+            controller.enqueue(new Uint8Array(chunk));
           }
           controller.close();
         },


### PR DESCRIPTION
depends on https://github.com/lucacasonato/deno-fetchevent/pull/1

This PR fixes chunked body handling. Deno.iter doesn't copy arraybuffer on each iteration. So we need to copy them at each iteration.